### PR TITLE
Support for SSH repos (Gitlab and github) and unit testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ workflows:
   build_and_publish:
     jobs:
       - build
+      - test
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,17 +24,14 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # store code coverage
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
-
   test:
     docker:
       - image: cimg/node:14.18.1
 
     working_directory: ~/repo
     steps:
+      - checkout
+
       - run: npm test
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,14 @@ jobs:
           root: ~/repo
           paths: .
 
+  test:
+    docker:
+      - image: cimg/node:14.18.1
+
+    working_directory: ~/repo
+    steps:
+      - run: npm test
+
   deploy:
     docker:
       - image: cimg/node:14.18.1

--- a/index.js
+++ b/index.js
@@ -74,10 +74,17 @@ module.exports = {
    */
   extractGitHubRepoPath: (url, returnUrl = false) => {
     if (!url) return "undefined_name";
-    const match = url.match(
-      /https?:\/\/(www\.)?github.com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
+    // Trying to match ssh based repo url
+    let match = url.match(
+      /git@(github|gitlab).com:(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
     );
-    if (!match || !match.groups || !(match.groups.owner && match.groups.name)) return null;
+    if (!match || !match.groups || !(match.groups.owner && match.groups.name)) {
+      // Let's try to match https based repo url
+      match = url.match(
+        /https?:\/\/(www\.)?(github|gitlab).com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
+      );
+      if (!match || !match.groups || !(match.groups.owner && match.groups.name)) return null
+    }
     return !returnUrl ? `${match.groups.name}` : `${match[0]}`;
   },
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/Kelsus/api-spot-package.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "author": "Kelsus",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kelsus/api-spot-package",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "description": "Spot Post deploy request",
   "main": "index.js",
   "bin": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const main = require('./index.js');
+
+const it = (desc, fn) => {
+  try {
+    fn();
+    console.log('\x1b[32m%s\x1b[0m', `${desc} \u2714`);
+  } catch (error) {
+    console.log('\n');
+    console.log('\x1b[31m%s\x1b[0m', `${desc} \u2718`);
+    console.error(error);
+  }
+};
+
+const desc = (desc, tests) => {
+  console.log('\x1b[32m%s\x1b[0m', desc);
+  tests();
+}
+
+desc("Test suite: extractGitHubRepoPath", () => {
+  it('Should get the project name from https://github.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://github.com/Kelsus/api-spot-package.git"), "api-spot-package");
+  });
+
+  it('Should get the project name from https://gitlab.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://gitlab.com/Kelsus/api-spot-package.git"), "api-spot-package");
+  });
+
+  it('Should get the project name from https://wwww.github.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://www.github.com/Kelsus/api-spot-package.git"), "api-spot-package");
+  });
+
+  it('Should get the project name from git@github.com:Kelsus/spot-api.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("git@github.com:Kelsus/spot-api.git"), "spot-api");
+  });
+
+  it('Should get the project name from git@gitlab.com:Kelsus/spot-api.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("git@gitlab.com:Kelsus/spot-api.git"), "spot-api");
+  });
+});
+
+


### PR DESCRIPTION
  - Now we support Gitlab repos as well
  - Support for ssh repos
  - Unit tests for `extractGitHubRepoPath`
  - Tests run on CircleCi