### PR TITLE
fix: Returning built URL for ssh github repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,18 +76,21 @@ module.exports = {
    */
   extractGitHubRepoPath: (url, returnUrl = false) => {
     if (!url) return "undefined_name";
-    // Trying to match ssh based repo url
+    // Let's try to match https based repo url
     let match = url.match(
-      /git@(github|gitlab).com:(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
+      /https?:\/\/(www\.)?(github|gitlab).com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
     );
-    if (!match || !match.groups || !(match.groups.owner && match.groups.name)) {
-      // Let's try to match https based repo url
-      match = url.match(
-        /https?:\/\/(www\.)?(github|gitlab).com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
-      );
-      if (!match || !match.groups || !(match.groups.owner && match.groups.name)) return null
-    }
-    return !returnUrl ? `${match.groups.name}` : `${match[0]}`;
+    if (match && match.groups && match.groups.owner && match.groups.name) 
+      return !returnUrl ? `${match.groups.name}` : `${match[0]}`;
+
+    // Now trying to match ssh based repo url
+    match = url.match(
+      /git@(?<server>[\w.-]+).com:(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
+    );
+    if (match && match.groups && match.groups.owner && match.groups.name) 
+      return !returnUrl ? `${match.groups.name}` : `https://${match.groups.server}.com/${match.groups.owner}/${match.groups.name}.git`;
+    else 
+      return null; 
   },
 
   /**

--- a/test.js
+++ b/test.js
@@ -22,20 +22,40 @@ desc("Test suite: extractGitHubRepoPath", () => {
     assert.strictEqual(main.extractGitHubRepoPath("https://github.com/Kelsus/api-spot-package.git"), "api-spot-package");
   });
 
+  it('Should get the project URL from https://github.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://github.com/Kelsus/api-spot-package.git", true), "https://github.com/Kelsus/api-spot-package.git");
+  });
+
   it('Should get the project name from https://gitlab.com/Kelsus/api-spot-package.git', () => {
     assert.strictEqual(main.extractGitHubRepoPath("https://gitlab.com/Kelsus/api-spot-package.git"), "api-spot-package");
+  });
+
+  it('Should get the project URL from https://gitlab.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://gitlab.com/Kelsus/api-spot-package.git", true), "https://gitlab.com/Kelsus/api-spot-package.git");
   });
 
   it('Should get the project name from https://wwww.github.com/Kelsus/api-spot-package.git', () => {
     assert.strictEqual(main.extractGitHubRepoPath("https://www.github.com/Kelsus/api-spot-package.git"), "api-spot-package");
   });
 
+  it('Should get the project URL from https://www.github.com/Kelsus/api-spot-package.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("https://www.github.com/Kelsus/api-spot-package.git", true), "https://www.github.com/Kelsus/api-spot-package.git");
+  });
+
   it('Should get the project name from git@github.com:Kelsus/spot-api.git', () => {
     assert.strictEqual(main.extractGitHubRepoPath("git@github.com:Kelsus/spot-api.git"), "spot-api");
   });
 
+  it('Should get the project URL from git@github.com:Kelsus/spot-api.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("git@github.com:Kelsus/spot-api.git", true), "https://github.com/Kelsus/spot-api.git");
+  });
+
   it('Should get the project name from git@gitlab.com:Kelsus/spot-api.git', () => {
     assert.strictEqual(main.extractGitHubRepoPath("git@gitlab.com:Kelsus/spot-api.git"), "spot-api");
+  });
+
+  it('Should get the project URL git@gitlab.com:Kelsus/spot-api.git', () => {
+    assert.strictEqual(main.extractGitHubRepoPath("git@gitlab.com:Kelsus/spot-api.git", true), "https://gitlab.com/Kelsus/spot-api.git");
   });
 });
 


### PR DESCRIPTION
Now we are returning URL (when required) for SSH based repos
```
Test suite: extractGitHubRepoPath
Should get the project name from https://github.com/Kelsus/api-spot-package.git ✔
Should get the project URL from https://github.com/Kelsus/api-spot-package.git ✔
Should get the project name from https://gitlab.com/Kelsus/api-spot-package.git ✔
Should get the project URL from https://gitlab.com/Kelsus/api-spot-package.git ✔
Should get the project name from https://wwww.github.com/Kelsus/api-spot-package.git ✔
Should get the project URL from https://www.github.com/Kelsus/api-spot-package.git ✔
Should get the project name from git@github.com:Kelsus/spot-api.git ✔
Should get the project URL from git@github.com:Kelsus/spot-api.git ✔
Should get the project name from git@gitlab.com:Kelsus/spot-api.git ✔
Should get the project URL git@gitlab.com:Kelsus/spot-api.git ✔
```