### PR TITLE
chore: Adding checkout on deploy step to ensure we are using last bumped version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - checkout
       - attach_workspace:
           at: ~/repo
       - run:


### PR DESCRIPTION
Before this change, publishing and notification to spot is being done with version before the bump. So we add another checkout action to ensure that deployment step brings bumped version as well.