### PR TITLE
fix: Changing extractGitHubRepoPath logic to avoid returing .git suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,17 +80,17 @@ module.exports = {
 
     // Let's try to match https based repo url
     let match = url.match(
-      /https?:\/\/(www\.)?(github|gitlab).com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
+      /https?:\/\/(www\.)?(?<server>[\w.-]+).com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
     );
     if (match && match.groups && match.groups.owner && match.groups.name) 
-      return !returnUrl ? `${match.groups.name}` : `${match[0]}`;
+      return returnUrl ? `https://${match.groups.server}.com/${match.groups.owner}/${match.groups.name}` : `${match.groups.name}`;
 
     // Now trying to match ssh based repo url
     match = url.match(
       /git@(?<server>[\w.-]+).com:(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
     );
     if (match && match.groups && match.groups.owner && match.groups.name) 
-      return !returnUrl ? `${match.groups.name}` : `https://${match.groups.server}.com/${match.groups.owner}/${match.groups.name}.git`;
+      return returnUrl ? `https://${match.groups.server}.com/${match.groups.owner}/${match.groups.name}` : `${match.groups.name}`;
 
     // Now trying to match http based git access
     // Ref: https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#http-based-git-access-by-an-installation
@@ -98,7 +98,7 @@ module.exports = {
       /https?:\/\/x\-access\-token\:(?<token>[\w.-]+)@github.com\/(?<owner>[\w.-]+)\/(?<name>[\w.-]+)\.git*/
     );
     if (match && match.groups && match.groups.owner && match.groups.name) 
-      return !returnUrl ? `${match.groups.name}` : `https://github.com/${match.groups.owner}/${match.groups.name}.git`;
+      return returnUrl ? `https://github.com/${match.groups.owner}/${match.groups.name}` : `${match.groups.name}`;
     else 
       return null;
   },
@@ -263,7 +263,7 @@ module.exports = {
 
     const remoteFromLocalGitRepoUrl = module.exports.extractGitHubRepoPath(remoteFromLocalGit, true);
 
-    console.log("Parameters extratec from local git:");
+    console.log("Parameters extrated from local git:");
     console.log({
       commitId,
       commitMessage,

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from https://github.com/Kelsus/api-spot-package.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("https://github.com/Kelsus/api-spot-package.git", true), "https://github.com/Kelsus/api-spot-package.git");
+    assert.strictEqual(index.extractGitHubRepoPath("https://github.com/Kelsus/api-spot-package.git", true), "https://github.com/Kelsus/api-spot-package");
   });
 
   it('Should get the project name from https://gitlab.com/Kelsus/api-spot-package.git', () => {
@@ -17,7 +17,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from https://gitlab.com/Kelsus/api-spot-package.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("https://gitlab.com/Kelsus/api-spot-package.git", true), "https://gitlab.com/Kelsus/api-spot-package.git");
+    assert.strictEqual(index.extractGitHubRepoPath("https://gitlab.com/Kelsus/api-spot-package.git", true), "https://gitlab.com/Kelsus/api-spot-package");
   });
 
   it('Should get the project name from https://wwww.github.com/Kelsus/api-spot-package.git', () => {
@@ -25,7 +25,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from https://www.github.com/Kelsus/api-spot-package.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("https://www.github.com/Kelsus/api-spot-package.git", true), "https://www.github.com/Kelsus/api-spot-package.git");
+    assert.strictEqual(index.extractGitHubRepoPath("https://www.github.com/Kelsus/api-spot-package.git", true), "https://github.com/Kelsus/api-spot-package");
   });
 
   it('Should get the project name from git@github.com:Kelsus/spot-api.git', () => {
@@ -33,7 +33,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from git@github.com:Kelsus/spot-api.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("git@github.com:Kelsus/spot-api.git", true), "https://github.com/Kelsus/spot-api.git");
+    assert.strictEqual(index.extractGitHubRepoPath("git@github.com:Kelsus/spot-api.git", true), "https://github.com/Kelsus/spot-api");
   });
 
   it('Should get the project name from git@gitlab.com:Kelsus/spot-api.git', () => {
@@ -41,7 +41,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from git@gitlab.com:Kelsus/spot-api.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("git@gitlab.com:Kelsus/spot-api.git", true), "https://gitlab.com/Kelsus/spot-api.git");
+    assert.strictEqual(index.extractGitHubRepoPath("git@gitlab.com:Kelsus/spot-api.git", true), "https://gitlab.com/Kelsus/spot-api");
   });
 
   it('Should get the project name from https://x-access-token:ghs_93UJtklu2SvM6CB9kqKNbGT4Q8eGcj1jHkRj@github.com/Kelsus/spot-api.git', () => {
@@ -49,7 +49,7 @@ describe("Test suite: extractGitHubRepoPath", () => {
   });
 
   it('Should get the project URL from https://x-access-token:ghs_93UJtklu2SvM6CB9kqKNbGT4Q8eGcj1jHkRj@github.com/Kelsus/spot-api.git', () => {
-    assert.strictEqual(index.extractGitHubRepoPath("https://x-access-token:ghs_93UJtklu2SvM6CB9kqKNbGT4Q8eGcj1jHkRj@github.com/Kelsus/spot-api.git", true), "https://github.com/Kelsus/spot-api.git");
+    assert.strictEqual(index.extractGitHubRepoPath("https://x-access-token:ghs_93UJtklu2SvM6CB9kqKNbGT4Q8eGcj1jHkRj@github.com/Kelsus/spot-api.git", true), "https://github.com/Kelsus/spot-api");
   });
 });
 


### PR DESCRIPTION
Sometimes repo URL was generated with `.git` suffix which is not necessary and brings issues when generating other URLs such as the commit urls