### PR TITLE
feat: Add support for ciRuntime and ciRuntimeVersion parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ npx @kelsus/api-spot-package --service=api-spot-package
 --serviceType
 --runtime
 --runtimeVersion
+--ciRuntime
+--ciRuntimeVersion
 --serviceUrl
 --repoUrl
 --lastDeploy

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ activity:
         serviceType,
         runtime,
         runtimeVersion,
+        ciRuntime,
+        ciRuntimeVersion,
         serviceUrl,
         repoUrl,
         lastDeploy,

--- a/functions/buildActivityBody.js
+++ b/functions/buildActivityBody.js
@@ -28,6 +28,8 @@ const buildActivityBody = (context) => {
     eventType = null,
     repoUrl = null,
     organization = null,
+    ciRuntime = null,
+    ciRuntimeVersion = null,
   } = context.activityParameters;
 
   const repositoryUrl = repoUrl ? repoUrl : context.resolvedRemoteGitURl;
@@ -59,6 +61,8 @@ const buildActivityBody = (context) => {
       ...(devDependencies && { devDependencies }),
       ...(serviceType && { serviceType }),
       ...(runtimeVersion && { runtimeVersion }),
+      ...(ciRuntime && { ciRuntime }),
+      ...(ciRuntimeVersion && { ciRuntimeVersion }),
       ...(serviceUrl && { serviceUrl }),
       ...(repositoryUrl && { repoUrl: repositoryUrl }),
     },

--- a/functions/getPropertiesFromArguments.js
+++ b/functions/getPropertiesFromArguments.js
@@ -15,6 +15,8 @@ const ALLOWED_ARGS = [
   "serviceType",
   "runtime",
   "runtimeVersion",
+  "ciRuntime",
+  "ciRuntimeVersion",
   "serviceUrl",
   "repoUrl",
   "lastDeploy",


### PR DESCRIPTION
Spot API already supports them since: https://github.com/Kelsus/spot-api/pull/90